### PR TITLE
Use https:// to refer to youtube.com

### DIFF
--- a/layouts/partials/video-responsive.html
+++ b/layouts/partials/video-responsive.html
@@ -7,7 +7,7 @@
 	</label>
 	<div class="attachments-video">
   	  <div class="video-responsive">
-	    <iframe id="widget2" src="http://www.youtube.com/embed/{{.Params.youtube}}?&amp;showinfo=0&amp;modestbranding=1&amp;autohide=1&amp;enablejsapi=1&amp;origin=https:%2F%2Fpapers.freebsd.org" allowfullscreen="" frameborder="0" height="360" width="640"></iframe>
+	    <iframe id="widget2" src="https://www.youtube.com/embed/{{.Params.youtube}}?&amp;showinfo=0&amp;modestbranding=1&amp;autohide=1&amp;enablejsapi=1&amp;origin=https:%2F%2Fpapers.freebsd.org" allowfullscreen="" frameborder="0" height="360" width="640"></iframe>
 	  </div>
 	</div>
     </section>

--- a/layouts/partials/video.html
+++ b/layouts/partials/video.html
@@ -7,7 +7,7 @@
 	</label>
 	<div class="attachments-video">
   	  <div class="video-responsive">
-	    <iframe id="widget2" src="http://www.youtube.com/embed/{{.Params.youtube}}?&amp;showinfo=0&amp;modestbranding=1&amp;autohide=1&amp;enablejsapi=1&amp;origin=https:%2F%2Fpapers.freebsd.org" allowfullscreen="" frameborder="0" height="360" width="640"></iframe>
+	    <iframe id="widget2" src="https://www.youtube.com/embed/{{.Params.youtube}}?&amp;showinfo=0&amp;modestbranding=1&amp;autohide=1&amp;enablejsapi=1&amp;origin=https:%2F%2Fpapers.freebsd.org" allowfullscreen="" frameborder="0" height="360" width="640"></iframe>
 	  </div>
 	</div>
     </section>


### PR DESCRIPTION
Fixes error:
Blocked loading mixed active content “http://www.youtube.com/embed/...”