### PR TITLE
Create _index.md for five of the 2017 conferences.

### DIFF
--- a/content/2017/FOSDEM/_index.md
+++ b/content/2017/FOSDEM/_index.md
@@ -1,0 +1,12 @@
+---
+title: FOSDEM 2017
+---
+4-5 February 2017, ULB Solbosch Campus, Brussels, Belgium.
+
+FOSDEM is a free and non-commercial event organised by the community for the community. The goal is to provide free and open source software developers and communities a place to meet to:
+
+* get in touch with other developers and projects;
+* be informed about the latest developments in the free software world;
+* be informed about the latest developments in the open source world;
+* attend interesting talks and presentations on various topics by project leaders and committers;
+* to promote the development and benefits of free software and open source solutions.

--- a/content/2017/asiabsdcon/_index.md
+++ b/content/2017/asiabsdcon/_index.md
@@ -1,0 +1,6 @@
+---
+title: AsiaBSDcon 2017
+---
+9-12 March 2017, Tokyo University of Science, Tokyo, Japan.
+
+AsiaBSDCon is a conference for users and developers on BSD based systems. The conference is for anyone developing, deploying and using systems based on FreeBSD, NetBSD, OpenBSD, DragonFlyBSD, Darwin and MacOS X. AsiaBSDCon is a technical conference and aims to collect the best technical papers and presentations available to ensure that the latest developments in our open source community are shared with the widest possible audience.

--- a/content/2017/bsdcan/_index.md
+++ b/content/2017/bsdcan/_index.md
@@ -1,0 +1,6 @@
+---
+title: BSDCan 2017
+---
+7-10 June 2017, University of Ottawa, Ottawa, Canada.
+
+BSDCan, a BSD conference held in Ottawa, Canada, quickly established itself as the technical conference for people working on and with 4.4BSD based operating systems and related projects. The organizers have found a fantastic formula that appeals to a wide range of people from extreme novices to advanced developers.

--- a/content/2017/bsdtw/_index.md
+++ b/content/2017/bsdtw/_index.md
@@ -1,0 +1,8 @@
+---
+title: BSD Taiwan 2017
+---
+11-12 November 2017, Beitou Resort, Taipei, Taiwan.
+
+BSDTW 2017 is planned as a single track, 2 days conference with 11 presentations of 50 minutes each covering the latest BSD technology. The conference will attract over 100 highly skilled engineering professionals, software developers, computer science professors, users and students from all over Asia as well as other parts of the world. The goal of BSDTW is to exchange knowledge about the BSD operating systems, facilitate coordination and cooperation among users and developers and to promote business friendly BSD licensed open source software.
+
+Taiwan has a long history with BSD systems, many of the top websites in Taiwan are using FreeBSD as their main server OS, also, OpenBSD and NetBSD are used in many products from local companies. In education networks, FreeBSD is usually the first choice for the server OS because of its stability and performance. There are more than a dozen FreeBSD developers and many BSD users in Taiwan, but they tend to be silent in the past few years, because of there is no event and they are busy at their positions. We believe BSDTW will draw in both old friends who are now serving important roles in companies or academia. By participating in BSDTW you can promote your company to decision makers, attract mind share, scout for highly skilled future employees or simply return something to the ecosystem if you are already using a BSD operating systems in your business or products.

--- a/content/2017/eurobsdcon/_index.md
+++ b/content/2017/eurobsdcon/_index.md
@@ -1,0 +1,6 @@
+---
+title: EuroBSDcon 2017
+---
+21-24 September 2017, Espace Saint Martin, Paris, France.
+
+EuroBSDcon is the premier European conference on the open source BSD operating systems attracting about 300 highly skilled engineering professionals, software developers, computer science students and professors, and users from all over Europe and other parts of the world. The goal of EuroBSDcon is to exchange knowledge about the BSD operating systems, facilitate coordination and cooperation among users and developers.


### PR DESCRIPTION
Feel free to reject this if you want.  No worries.  I was doing a quick check of my last commit when I noticed it.  I am torn between the talks being mostly listed on the main page (with one duplicate titled talk given at two conferences), or 5 conferences with just a couple of talks in each.

