### PR TITLE
Create _index.md for BSDCan 2020

### DIFF
--- a/content/2020/BSDcan/_index.md
+++ b/content/2020/BSDcan/_index.md
@@ -1,0 +1,6 @@
+---
+title: BSDCan
+---
+3-6 June 2020, Streamed online
+
+BSDCan 2020, the 17th Annual BSD conference, quickly established itself as the technical conference for people working on and with 4.4BSD based operating systems and related projects. The organizers have found a fantastic formula that appeals to a wide range of people from extreme novices to advanced developers.


### PR DESCRIPTION
Hugo wasn't creating the page for the conference, so the papers were listed as at the year's level and doesn't seem to pick up the slides.