### PR TITLE
Cirrus CI: Switch to on-premises worker

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,14 +1,12 @@
 env:
   CIRRUS_CLONE_DEPTH: 1
-  ARCH: amd64
 
 task:
-  freebsd_instance:
-    image: freebsd-13-2-release-amd64
-  install_script:
-    - sed -i.bak -e 's,pkg+http://pkg.FreeBSD.org/\${ABI}/quarterly,pkg+http://pkg.FreeBSD.org/\${ABI}/latest,' /etc/pkg/FreeBSD.conf
-    - pkg install -y git-tiny gohugo
-  script:
+  persistent_worker:
+    labels:
+      jail: FreeBSD-14-0-release-doc
+  timeout_in: 20m
+  test_script:
     - git submodule init
     - git submodule update
     - hugo


### PR DESCRIPTION
Cirrus CI is currently not operational for us due to exceeding the monthly free compute limit.

This temporarily disables Cirrus CI public instances in favor of an on-premises worker hosted in the FreeBSD cluster for testing purposes.

This is the same worker used for the FreeBSD Documentation.